### PR TITLE
Chinese translation for most of content

### DIFF
--- a/web/build/vue-loader.conf.js
+++ b/web/build/vue-loader.conf.js
@@ -5,12 +5,18 @@ const config = require('../config');
 const isProduction = process.env.NODE_ENV === 'production';
 
 module.exports = {
-  loaders: utils.cssLoaders({
-    sourceMap: isProduction
-      ? config.build.productionSourceMap
-      : config.dev.cssSourceMap,
-    extract: isProduction,
-  }),
+  preLoaders: {
+    i18n: 'yaml-loader',
+  },
+  loaders: {
+    ...utils.cssLoaders({
+      sourceMap: isProduction
+        ? config.build.productionSourceMap
+        : config.dev.cssSourceMap,
+      extract: isProduction,
+    }),
+    i18n: '@kazupon/vue-i18n-loader',
+  },
   transformToRequire: {
     video: 'src',
     source: 'src',

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@kazupon/vue-i18n-loader": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@kazupon/vue-i18n-loader/-/vue-i18n-loader-0.2.1.tgz",
+      "integrity": "sha512-63ZqDKKpmWB48ZNbLO9y/HFHxmNHImAL75ZTcipOjxSqgV+m+E3JFoUntnDhijHxtENNZaoELsTGI96WIIrVzQ=="
+    },
     "accepts": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
@@ -9252,6 +9257,11 @@
       "integrity": "sha512-Hn0jdFiNfNx4+Nxz1vokYUsP3mwpn9r/XomLrXA+KafYaiR7LNQG1fxtpVklD4KxD5GluXRiSoWNDf0H9BdsJw==",
       "dev": true
     },
+    "vue-i18n": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-7.4.2.tgz",
+      "integrity": "sha512-RFUM24Qa6PpJMmoV5IEGIv5GaZ7v0EE2rTXco2lanbyC52qLszh+NFgzhfbwCZgpf94+Sih+oHOAh/YMbGvofg=="
+    },
     "vue-lazyload": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/vue-lazyload/-/vue-lazyload-1.1.4.tgz",
@@ -9672,6 +9682,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yaml-loader": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/yaml-loader/-/yaml-loader-0.5.0.tgz",
+      "integrity": "sha512-p9QIzcFSNm4mCw/m5NdyMfN4RE4aFZJWRRb01ERVNGCym8VNbKtw3OYZXnvUIkim6U/EjqE/2yIh9F/msShH9A==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.10.0"
+      }
     },
     "yargs": {
       "version": "8.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -17,12 +17,14 @@
     "bootstrap-vue": "^1.0.0",
     "moment": "^2.19.1",
     "vue": "^2.5.2",
+    "vue-i18n": "^7.4.2",
     "vue-lazyload": "^1.1.4",
     "vue-router": "^3.0.1",
     "vue-scrollto": "^2.8.0",
     "vuex": "^3.0.1"
   },
   "devDependencies": {
+    "@kazupon/vue-i18n-loader": "^0.2.1",
     "autoprefixer": "^7.1.2",
     "babel-core": "^6.22.1",
     "babel-eslint": "^7.1.1",
@@ -67,7 +69,8 @@
     "webpack-bundle-analyzer": "^2.9.0",
     "webpack-dev-middleware": "^1.12.0",
     "webpack-hot-middleware": "^2.18.2",
-    "webpack-merge": "^4.1.0"
+    "webpack-merge": "^4.1.0",
+    "yaml-loader": "^0.5.0"
   },
   "engines": {
     "node": ">= 4.0.0",

--- a/web/src/assets/lang.yaml
+++ b/web/src/assets/lang.yaml
@@ -1,0 +1,189 @@
+en:
+  advancement:
+    minecraft:story/root: Minecraft
+    minecraft:story/mine_stone: Stone Age
+    minecraft:story/upgrade_tools: Getting an Upgrade
+    minecraft:story/smelt_iron: Acquire Hardware
+    minecraft:story/obtain_armor: Suit Up
+    minecraft:story/lava_bucket: Hot Stuff
+    minecraft:story/iron_tools: Isn't It Iron Pick
+    minecraft:story/deflect_arrow: Not Today, Thank You
+    minecraft:story/form_obsidian: Ice Bucket Challenge
+    minecraft:story/mine_diamond: Diamonds!
+    minecraft:story/enter_the_nether: We Need to Go Deeper
+    minecraft:story/shiny_gear: Cover Me With Diamonds
+    minecraft:story/enchant_item: Enchanter
+    minecraft:story/cure_zombie_villager: Zombie Doctor
+    minecraft:story/follow_ender_eye: Eye Spy
+    minecraft:story/enter_the_end: The End?
+    minecraft:nether/root: Nether
+    minecraft:nether/fast_travel: Subspace Bubble
+    minecraft:nether/find_fortress: A Terrible Fortress
+    minecraft:nether/return_to_sender: Return to Sender
+    minecraft:nether/obtain_blaze_rod: Into Fire
+    minecraft:nether/get_wither_skull: Spooky Scary Skeleton
+    minecraft:nether/uneasy_alliance: Uneasy Alliance
+    minecraft:nether/brew_potion: Local Brewery
+    minecraft:nether/summon_wither: Withering Heights
+    minecraft:nether/all_potions: A Furious Cocktail
+    minecraft:nether/create_beacon: Bring Home the Beacon
+    minecraft:nether/all_effects: How Did We Get Here?
+    minecraft:nether/create_full_beacon: Beaconator
+    minecraft:end/root: The End
+    minecraft:end/kill_dragon: Free the End
+    minecraft:end/dragon_egg: The Next Generation
+    minecraft:end/enter_end_gateway: Remote Getaway
+    minecraft:end/respawn_dragon: The End... Again...
+    minecraft:end/dragon_breath: You Need a Mint
+    minecraft:end/find_end_city: The City at the End of the Game
+    minecraft:end/elytra: Sky's the Limit
+    minecraft:end/levitate: Great View From Up Here
+    minecraft:adventure/root: Adventure
+    minecraft:adventure/kill_a_mob: Monster Hunter
+    minecraft:adventure/trade: What a Deal!
+    minecraft:adventure/sleep_in_bed: Sweet dreams
+    minecraft:adventure/shoot_arrow: Take Aim
+    minecraft:adventure/kill_all_mobs: Monsters Hunted
+    minecraft:adventure/totem_of_undying: Postmortal
+    minecraft:adventure/summon_iron_golem: Hired Help
+    minecraft:adventure/adventuring_time: Adventuring Time
+    minecraft:adventure/sniper_duel: Sniper duel
+    minecraft:husbandry/root: Husbandry
+    minecraft:husbandry/breed_an_animal: The Parrots and the Bats
+    minecraft:husbandry/tame_an_animal: Best Friends Forever
+    minecraft:husbandry/plant_seed: A Seedy Place
+    minecraft:husbandry/bred_all_animals: Two by Two
+    minecraft:husbandry/balanced_diet: A Balanced Diet
+    minecraft:husbandry/break_diamond_hoe: Serious Dedication
+  achievement:
+    openInventory: Taking Inventory
+    mineWood: Getting Wood
+    buildWorkBench: Benchmarking
+    buildPickaxe: Time to Mine!
+    buildFurnace: Hot Topic
+    acquireIron: Acquire Hardware
+    buildHoe: Time to Farm!
+    makeBread: Bake Bread
+    bakeCake: The Lie
+    buildBetterPickaxe: Getting an Upgrade
+    cookFish: Delicious Fish
+    onARail: On A Rail
+    buildSword: Time to Strike!
+    killEnemy: Monster Hunter
+    killCow: Cow Tipper
+    flyPig: When Pigs Fly
+    snipeSkeleton: Sniper Duel
+    diamonds: DIAMONDS!
+    portal: We Need to Go Deeper
+    ghast: Return to Sender
+    blazeRod: Into Fire
+    potion: Local Brewery
+    theEnd: The End?
+    theEnd2: The End.
+    enchantments: Enchanter
+    overkill: Overkill
+    bookcase: Librarian
+    exploreAllBiomes: Adventuring Time
+    spawnWither: The Beginning?
+    killWither: The Beginning.
+    fullBeacon: Beaconator
+    breedCow: Repopulation
+    diamondsToYou: Diamonds to you!
+    overpowered: Overpowered
+  stat:
+    walkOneCm: meters walked
+    crouchOneCm: meters crouched
+    sprintOneCm: meters sprinted
+    swimOneCm: meters swum
+    fallOneCm: meters fallen
+    climbOneCm: meters climbed
+    diveOneCm: meters dove
+    minecartOneCm: meters in minecart
+    boatOneCm: meters on boat
+    horseOneCm: meters with Horse
+    aviateOneCm: meters gliding with elytra
+    jump: jumps
+    damageDealt: damage dealt
+    damageTaken: damage taken
+    deaths: deaths
+    mobKills: mob killed
+    playerKills: player killed
+    fishCaught: fish caught
+    tradedWithVillager: traded with villagers
+zh-cn:
+  advancement:
+    minecraft:story/root: Minecraft
+    minecraft:story/mine_stone: 石器时代
+    minecraft:story/upgrade_tools: 获得升级
+    minecraft:story/smelt_iron: 来硬的
+    minecraft:story/obtain_armor: 整装上阵
+    minecraft:story/lava_bucket: 热腾腾的
+    minecraft:story/iron_tools: 这不是铁镐么
+    minecraft:story/deflect_arrow: 抱歉，今天不行
+    minecraft:story/form_obsidian: 冰桶挑战
+    minecraft:story/mine_diamond: 钻石！
+    minecraft:story/enter_the_nether: 我们需要再深入些
+    minecraft:story/shiny_gear: 用钻石包裹我
+    minecraft:story/enchant_item: 附魔师
+    minecraft:story/cure_zombie_villager: 僵尸科医生
+    minecraft:story/follow_ender_eye: 隔墙有眼
+    minecraft:story/enter_the_end: 结束了？
+    minecraft:nether/root: 下界
+    minecraft:nether/fast_travel: 子空间泡泡
+    minecraft:nether/find_fortress: 可怕的要塞
+    minecraft:nether/return_to_sender: 见鬼去吧
+    minecraft:nether/obtain_blaze_rod: 与火共舞
+    minecraft:nether/get_wither_skull: 诡异又可怕的骷髅
+    minecraft:nether/uneasy_alliance: 不稳定的同盟
+    minecraft:nether/brew_potion: 本地的酿造厂
+    minecraft:nether/summon_wither: 凋零山庄
+    minecraft:nether/all_potions: 狂乱的鸡尾酒
+    minecraft:nether/create_beacon: 带信标回家
+    minecraft:nether/all_effects: 为什么会变成这样呢？
+    minecraft:nether/create_full_beacon: 信标工程师
+    minecraft:end/root: 末地
+    minecraft:end/kill_dragon: 解放末地
+    minecraft:end/dragon_egg: 下一世代
+    minecraft:end/enter_end_gateway: 远程折跃
+    minecraft:end/respawn_dragon: 结束了…再一次…
+    minecraft:end/dragon_breath: 你需要来点薄荷糖
+    minecraft:end/find_end_city: 在游戏尽头的城市
+    minecraft:end/elytra: 天空即为极限
+    minecraft:end/levitate: 这上面的风景不错
+    minecraft:adventure/root: 冒险
+    minecraft:adventure/kill_a_mob: 怪物猎人
+    minecraft:adventure/trade: 这交易不错！
+    minecraft:adventure/sleep_in_bed: 甜蜜的梦
+    minecraft:adventure/shoot_arrow: 瞄准目标
+    minecraft:adventure/kill_all_mobs: 怪物狩猎完成
+    minecraft:adventure/totem_of_undying: 超越生死
+    minecraft:adventure/summon_iron_golem: 招募援兵
+    minecraft:adventure/adventuring_time: 探索的时光
+    minecraft:adventure/sniper_duel: 狙击手间的对决
+    minecraft:husbandry/root: 农牧业
+    minecraft:husbandry/breed_an_animal: 我从哪儿来？
+    minecraft:husbandry/tame_an_animal: 永恒的伙伴
+    minecraft:husbandry/plant_seed: 开荒垦地
+    minecraft:husbandry/bred_all_animals: 成双成对
+    minecraft:husbandry/balanced_diet: 均衡饮食
+    minecraft:husbandry/break_diamond_hoe: 终极奉献
+  stat:
+    walkOneCm: 米行走距离
+    crouchOneCm: 米潜行距离
+    sprintOneCm: 米疾跑距离
+    swimOneCm: 米有用距离
+    fallOneCm: 米下落距离
+    climbOneCm: 米攀爬距离
+    diveOneCm: 米潜水距离
+    minecartOneCm: 米矿车行驶距离
+    boatOneCm: 米划船距离
+    horseOneCm: 米骑马距离
+    aviateOneCm: 米鞘翅滑翔距离
+    jump: 次跳跃
+    damageDealt: 点造成伤害
+    damageTaken: 点承受伤害
+    deaths: 次死亡
+    mobKills: 次生物击杀
+    playerKills: 次玩家击杀
+    fishCaught: 次鱼获
+    tradedWithVillager: 次村民交易

--- a/web/src/components/AdvancementBlock.vue
+++ b/web/src/components/AdvancementBlock.vue
@@ -8,16 +8,16 @@
           </div>
           <div class="media-body text-middle">
             <h4 class="media-heading">
-              {{ lang.advancement[adv.advId] }}<br/>
+              {{$t(`advancement['${adv.advId}']`)}}<br/>
               <small>
                 <span v-if="adv.progTotal !== 0">
-                  Completed {{ adv.prog }} / {{ adv.progTotal }}
+                  {{$t('completed')}} {{ adv.prog }} / {{ adv.progTotal }}
                 </span>
                 <span v-else-if="adv.prog > 1 && adv.progTotal === 0">
-                  Completed: {{ adv.prog }}
+                  {{$t('completed')}}: {{ adv.prog }}
                 </span>
                 <span v-else>
-                  Completed
+                  {{$t('completed')}}
                 </span>
               </small>
             </h4>
@@ -29,17 +29,11 @@
 </template>
 
 <script>
-import lang from '../assets/lang.json';
 import { advancements } from '../assets/advancements';
 
 export default {
   name: 'AdvancementBlock',
   props: ['adv'],
-  data() {
-    return {
-      lang,
-    };
-  },
   computed: {
     getImg() {
       return advancements[this.adv.type][this.adv.adv];
@@ -48,3 +42,12 @@ export default {
 };
 
 </script>
+
+<i18n src="@/assets/lang.yaml"></i18n>
+
+<i18n>
+en:
+  completed: Completed
+zh-cn:
+  completed: 已完成
+</i18n>

--- a/web/src/components/Membership.vue
+++ b/web/src/components/Membership.vue
@@ -4,7 +4,7 @@
       <div class="panel-heading">
         <h3 class="panel-title">
           <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>&nbsp;
-          Membership
+          {{$t('title')}}
         </h3>
       </div>
       <div class="panel-body">
@@ -13,19 +13,19 @@
             <h4 class="list-group-item-heading">
               {{timeStart}}
             </h4>
-            <p class="list-group-item-text text-muted">First Login</p>
+            <p class="list-group-item-text text-muted">{{$t('first-login')}}</p>
           </li>
           <li v-if="player.data.time_last" class="list-group-item">
             <h4 class="list-group-item-heading">
               {{timeLast}}
             </h4>
-            <p class="list-group-item-text text-muted">Last Active</p>
+            <p class="list-group-item-text text-muted">{{$t('last-active')}}</p>
           </li>
           <li v-if="player.data.time_lived" class="list-group-item">
             <h4 class="list-group-item-heading">
-              {{timeLived}} Hours
+              {{timeLived}} {{$tc('hours', timeLived)}}
             </h4>
-            <p class="list-group-item-text text-muted">Total Online</p>
+            <p class="list-group-item-text text-muted">{{$t('total-online')}}</p>
           </li>
         </div>
       </div>
@@ -56,3 +56,18 @@ export default {
   },
 };
 </script>
+
+<i18n>
+en:
+  title: Membership
+  first-login: First Login
+  last-active: Last Active
+  hours: Hours | Hour | Hours
+  total-online: Total Online
+zh-cn:
+  title: 账号
+  first-login: 首次登录
+  last-active: 最近活动
+  hours: 小时
+  total-online: 总计在线
+</i18n>

--- a/web/src/components/Name.vue
+++ b/web/src/components/Name.vue
@@ -2,7 +2,7 @@
   <li class="list-group-item">
     <h5>
       {{name.name}}
-      <small v-if="name.changedToAt">Changed at {{changedToAt}}</small>
+      <small v-if="name.changedToAt">{{$t('changed-at')}} {{changedToAt}}</small>
       <small v-if="!name.changedToAt"></small>
     </h5>
   </li>
@@ -25,3 +25,10 @@ export default {
   },
 };
 </script>
+
+<i18n>
+en:
+  changed-at: Changed at
+zh-cn:
+  changed-at: 变更于
+</i18n>

--- a/web/src/components/NameHistory.vue
+++ b/web/src/components/NameHistory.vue
@@ -4,7 +4,7 @@
       <div class="panel-heading">
         <h3 class="panel-title">
           <span class="glyphicon glyphicon-time" aria-hidden="true"></span>&nbsp;
-          Name History
+          {{$t('title')}}
         </h3>
       </div>
       <div class="panel-body">
@@ -27,3 +27,10 @@ export default {
   },
 };
 </script>
+
+<i18n>
+  en:
+    title: Name History
+  zh-cn:
+    title: 名称历史
+</i18n>

--- a/web/src/components/Navbar.vue
+++ b/web/src/components/Navbar.vue
@@ -12,6 +12,12 @@
           {{ info.title }}
         </router-link>
       </div>
+      <label class="i18n-menu">
+        <select v-model="locale">
+          <option value="en">English</option>
+          <option value="zh-cn">中文</option>
+        </select>
+      </label>
     </div>
   </nav>
 </template>
@@ -24,6 +30,35 @@ export default {
   computed: mapState([
     'info',
   ]),
+  data() {
+    return {
+      locale: this.$i18n.locale,
+    };
+  },
+  watch: {
+    locale(val) {
+      this.$i18n.locale = val;
+    },
+  },
 };
-
 </script>
+
+<style>
+  .i18n-menu {
+    display: block;
+    float: right;
+    margin: 0;
+    line-height: 50px;
+    font-weight: normal;
+  }
+
+  .i18n-menu select {
+    border: 0;
+    background: transparent;
+    color: #d9d9d9;
+  }
+
+  .i18n-menu option {
+    color: #000;
+  }
+</style>

--- a/web/src/components/PlayerAdvancement.vue
+++ b/web/src/components/PlayerAdvancement.vue
@@ -1,39 +1,39 @@
 <template>
   <div v-if="player.advancements">
     <div class="row" v-if="advTotal > 0">
-      <h3>Advancements</h3>
+      <h3>{{$t('advancements')}}</h3>
       <hr/>
       <div class="row" v-if="advStory.length > 0">
         <div class="col-md-12">
-          <h4>Story</h4>
+          <h4>{{$t('advancement["minecraft:story/root"]')}}</h4>
           <hr/>
           <AdvancementBlock v-for="adv in advStory" :key="adv.advId" :adv="adv"></AdvancementBlock>
         </div>
       </div>
       <div class="row" v-if="advNether.length > 0">
         <div class="col-md-12">
-          <h4>Nether</h4>
+          <h4>{{$t('advancement["minecraft:nether/root"]')}}</h4>
           <hr/>
           <AdvancementBlock v-for="adv in advNether" :key="adv.advId" :adv="adv"></AdvancementBlock>
           </div>
       </div>
       <div class="row" v-if="advEnd.length > 0">
         <div class="col-md-12">
-          <h4>The End</h4>
+          <h4>{{$t('advancement["minecraft:end/root"]')}}</h4>
           <hr/>
           <AdvancementBlock v-for="adv in advEnd" :key="adv.advId" :adv="adv"></AdvancementBlock>
         </div>
       </div>
       <div class="row" v-if="advAdventure.length > 0">
         <div class="col-md-12">
-          <h4>Adventure</h4>
+          <h4>{{$t('advancement["minecraft:adventure/root"]')}}</h4>
           <hr/>
           <AdvancementBlock v-for="adv in advAdventure" :key="adv.advId" :adv="adv"></AdvancementBlock>
         </div>
       </div>
       <div class="row" v-if="advHusbandry.length > 0">
         <div class="col-md-12">
-          <h4>Husbandry</h4>
+          <h4>{{$t('advancement["minecraft:husbandry/root"]')}}</h4>
           <hr/>
           <AdvancementBlock v-for="adv in advHusbandry" :key="adv.advId" :adv="adv"></AdvancementBlock>
         </div>
@@ -42,7 +42,7 @@
   </div>
 
   <div class="row" v-else>
-    <h3>Achievements</h3>
+    <h3>{{$t('achievements')}}</h3>
     <hr/>
     <AchievementBlock v-for="(prop, index) in Object.keys(player.stats)" :key="index" :player="player" :prop="prop" />
   </div>
@@ -127,3 +127,22 @@ export default {
   },
 };
 </script>
+
+<i18n src="@/assets/lang.yaml"></i18n>
+
+<i18n>
+en:
+  advancements: Advancements
+  nether: Nether
+  the_end: The End
+  adventure: Adventure
+  husbandry: Husbandry
+  achievements: Achievements
+zh-cn:
+  advancements: 进度
+  nether: 下界
+  the_end: 末地
+  adventure: 冒险
+  husbandry: 农牧业
+  achievements: 成就
+</i18n>

--- a/web/src/components/PlayerList.vue
+++ b/web/src/components/PlayerList.vue
@@ -8,7 +8,7 @@
     </b-alert>
     <b-progress v-show="loading" :value="100" :max="100" animated class="mb-3"></b-progress>
     <b-row class="searchbox">
-      <b-col sm="12"><b-form-input id="input-none" type="text" :value="keyword" @input="updateKeyword" placeholder="Search user by Name / UUID"></b-form-input></b-col>
+      <b-col sm="12"><b-form-input id="input-none" type="text" :value="keyword" @input="updateKeyword" :placeholder="$t('search-placeholder')"></b-form-input></b-col>
     </b-row>
     <lazy-component class="row">
       <playerblock v-for="(player, key, index) in playerList" :key="index" :player="player" v-show="search(player)"></playerblock>
@@ -135,3 +135,9 @@ export default {
 }
 </style>
 
+<i18n>
+en:
+  search-placeholder: Search user by Name / UUID
+zh-cn:
+  search-placeholder: 按名称/UUID查询
+</i18n>

--- a/web/src/components/PlayerPage.vue
+++ b/web/src/components/PlayerPage.vue
@@ -29,8 +29,8 @@
 
       <div class="row">
         <ol class="breadcrumb">
-          <li><router-link to="/">Home</router-link></li>
-          <li>Player</li>
+          <li><router-link to="/">{{$t('home')}}</router-link></li>
+          <li>{{$t('player')}}</li>
           <li class="active">{{player.data.playername}}</li>
         </ol>
       </div>
@@ -143,3 +143,12 @@ export default {
   padding: 0;
 }
 </style>
+
+<i18n>
+en:
+  home: Home
+  player: Player
+zh-cn:
+  home: 首页
+  player: 玩家
+</i18n>

--- a/web/src/components/PlayerStatistic.vue
+++ b/web/src/components/PlayerStatistic.vue
@@ -1,25 +1,26 @@
 <template>
   <div class="row">
-    <h3>Statistics</h3>
+    <h3>{{$t('section-title')}}</h3>
     <hr/>
     <statistic-block v-for="(prop, index) in Object.keys(player.stats)" :key="index" :player="player" :prop="prop" />
   </div>
 </template>
 
 <script>
-import lang from '../assets/lang.json';
 import StatisticBlock from './StatisticBlock';
 
 export default {
   name: 'PlayerStatistic',
   props: ['player'],
-  data() {
-    return {
-      lang,
-    };
-  },
   components: {
     StatisticBlock,
   },
 };
 </script>
+
+<i18n>
+en:
+  section-title: Statistics
+zh-cn:
+  section-title: 统计
+</i18n>

--- a/web/src/components/StatisticBlock.vue
+++ b/web/src/components/StatisticBlock.vue
@@ -5,9 +5,7 @@
         <span class="glyphicon glyphicon-stats" aria-hidden="true"></span>
         &nbsp;
         <span class="text-primary">{{ numAbbr(player.stats[prop]) }}</span>
-        <span class="text-muted">
-        {{ lang.stat[ac[1]] }}
-      </span>
+        <span class="text-muted">{{$t('stat.' + ac[1])}}</span>
       </div>
     </div>
   </div>
@@ -56,3 +54,4 @@ export default {
 };
 </script>
 
+<i18n src="@/assets/lang.yaml"></i18n>

--- a/web/src/components/StatisticBlock.vue
+++ b/web/src/components/StatisticBlock.vue
@@ -28,7 +28,8 @@ export default {
   },
   methods: {
     numAbbr(val) {
-      const value = Math.round(val);
+      // If it is a *OneCm stat, convert it into meters
+      const value = Math.round(/OneCm$/.test(this.ac[1]) ? val / 100 : val);
       let newValue = value;
       if (value >= 1000) {
         const suffixes = ['', 'k', 'M', 'b'];

--- a/web/src/components/Welcome.vue
+++ b/web/src/components/Welcome.vue
@@ -2,9 +2,9 @@
   <div class="jumbotron">
     <div class="container">
       <h1>{{info.servername}}</h1>
-      <p>Server time elapsed {{worldTime}}</p>
+      <p>{{$t('server-time-elapsed')}} {{worldTime}}</p>
 
-      <p><a class="btn btn-primary btn-lg" v-bind:href="homePage" role="button">Learn more &raquo;</a></p>
+      <p><a class="btn btn-primary btn-lg" v-bind:href="homePage" role="button">{{$t('learn-more')}} &raquo;</a></p>
 
     </div>
   </div>
@@ -28,5 +28,13 @@ export default {
     },
   },
 };
-
 </script>
+
+<i18n>
+en:
+  server-time-elapsed: Server time elapsed
+  learn-more: Learn more
+zh-cn:
+  server-time-elapsed: 服务器时间已经过
+  learn-more: 了解更多
+</i18n>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -6,6 +6,7 @@ import Vuex from 'vuex';
 import BootstrapVue from 'bootstrap-vue';
 import VueLazyload from 'vue-lazyload';
 import VueScrollTo from 'vue-scrollto';
+import VueI18n from 'vue-i18n';
 import 'bootstrap/dist/css/bootstrap.css';
 import 'bootstrap-vue/dist/bootstrap-vue.css';
 
@@ -20,6 +21,7 @@ Vue.use(VueLazyload, {
 });
 Vue.use(VueScrollTo);
 Vue.use(Vuex);
+Vue.use(VueI18n);
 
 export const store = new Vuex.Store({
   state: {
@@ -59,13 +61,22 @@ export const store = new Vuex.Store({
   },
 });
 
+const i18n = new VueI18n({
+  locale: 'en',
+  fallbackLocale: 'en',
+});
+
 /* eslint-disable no-new */
 new Vue({
   el: '#app',
   router,
   store,
+  i18n,
   template: '<App/>',
   components: { App },
+  created() {
+    this.$i18n.locale = (window.navigator.language || window.navigator.userLanguage).toLowerCase();
+  },
 });
 
 export default store;


### PR DESCRIPTION
There're some texts currently not translated:

- Server name, since it's controlled by remote JSON
- Date/Time, since I just don't like the size of moment-locales and the works of replacing all moment.js usages (Anyway it shouldn't be too hard to understand in English)
- Achievements, since I didn't find an official translation of original achievements from Gamepedia (Seems they completely deleted the 1.11 version of PC achievements data)

To efficiently use the newly-imported `vue-i18n` module, I copied the `lang.json` as `lang.yaml` and kept the original file for reference safety. But it should be OK to deprecate the `lang.json` (which has no i18n functionality at all XD).

Translation of statistics may look awkward, because I was trying not to modify the DOM. I will send another PR to solve this problem, if it is a problem.

---

**0309:** Make the number and label consistent in unit for *OneCm stats.